### PR TITLE
Revert "chore(deps): update pypa/gh-action-pypi-publish action to v1.…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -871,7 +871,7 @@ jobs:
         run: ls -alh dist/
       - name: Publish to PyPI
         if: needs.Prepare.outputs.update_channel == 'latest'
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           packages-dir: dist/
   Release:


### PR DESCRIPTION
…14.2 (#267)"

This reverts commit 27b8a0efda1207c65c24b3f5865e01d3d0a8a899.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/colopl/colopresso/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->